### PR TITLE
s/defprotocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
  * Fix mutually recursive `s/letfn` bindings
  * Fix `s/fn` perf caveats in Clojure by avoiding wrappers
+ * Add `s/defprotocol`
 
 ## 1.2.0 (`2021-11-03`)
  * **BREAKING** use `cljc` instead of `cljx`, which requires Clojure 1.7 or later. (#425)

--- a/project.clj
+++ b/project.clj
@@ -14,20 +14,18 @@
                              [lein-release/lein-release "1.0.4"]
                              [lein-doo "0.1.10"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"] [org.clojure/clojurescript "1.10.520"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"] [org.clojure/clojurescript "1.10.879"]]}
-             :1.11 {:dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"] [org.clojure/clojurescript "1.10.879"]]
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"] [org.clojure/clojurescript "1.10.891"]]}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"] [org.clojure/clojurescript "1.10.891"]]
                     :repositories [["sonatype-oss-public" {:url "https://oss.sonatype.org/content/groups/public"}]]}}
 
   :aliases {"all" ["with-profile" "+dev:+1.9:+1.10:+1.11"]
             "deploy" ["do" "clean," "deploy" "clojars"]
-            "test" ["do" "clean," "test," "doo" "node" "test" "once"]}
+            "test" ["do" "clean," "test," "clean," "doo" "node" "test" "once"]}
 
   :jar-exclusions [#"\.swp|\.swo|\.DS_Store"]
 
   :lein-release {:deploy-via :shell
                  :shell ["lein" "deploy"]}
-
-  :auto-clean false
 
   :source-paths ["src/clj" "src/cljc"]
 

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -362,6 +362,155 @@
              (new ~(symbol (str name))
                   ~@(map (fn [s] `(safe-get ~map-sym ~(keyword s))) field-schema)))))))
 
+(defn -instrument-protocol-method
+  "Given a protocol Var pvar, its method method-var and instrument-method,
+  instrument the protocol method."
+  [pvar ;:- Var
+   method-var ;:- (Var InnerMth)
+   instrument-method #_:- #_(s/=>* OuterMth
+                                   [InnerMth
+                                    (named (=> Any OuterMth InnerMth)
+                                           'sync!)])]
+  (let [;; propagate method cache to inner method
+        sync! (fn [^clojure.lang.AFunction outer-mth
+                   ^clojure.lang.AFunction inner-mth]
+                (when-not (identical? (.__methodImplCache outer-mth)
+                                      (.__methodImplCache inner-mth))
+                  ;; lock to prevent outdated outer caches from overwriting newer inner caches
+                  (locking inner-mth
+                    (set! (.__methodImplCache inner-mth)
+                          ;; vv WARNING: must be calculated within protected area
+                          (.__methodImplCache outer-mth)
+                          ;; ^^ WARNING: must be calculated within protected area
+                          ))))
+        ^clojure.lang.AFunction inner-mth @method-var
+        ^clojure.lang.AFunction outer-mth (instrument-method inner-mth sync!)
+        ;; populate outer cache so we can use outer-mth as the protocol method without needing
+        ;; to call -reset-methods.
+        _ (set! (.__methodImplCache outer-mth)
+                (.__methodImplCache inner-mth))
+        method-builder (fn [cache]
+                         (set! (.__methodImplCache outer-mth) cache)
+                         (sync! outer-mth inner-mth)
+                         ;; preempt future fix for CLJ-1796--have a canonical method
+                         ;; representation for the duration of the protocol, matching
+                         ;; CLJS semantics.
+                         outer-mth)]
+    ;; instrument method builder
+    (alter-var-root pvar assoc-in [:method-builders method-var] method-builder)
+    ;; defeat Compiler.java inlining capabilities so we can always enforce schemas
+    (alter-meta! method-var assoc :inline (fn [& args]
+                                            `((do ~(symbol (-> *ns* ns-name name) (str (.sym ^clojure.lang.Var method-var))))
+                                              ~@args)))
+    ;; instrument the actual method
+    (alter-var-root method-var (fn [_] outer-mth))))
+
+(defn parse-defprotocol-sig [env pname name+sig+doc]
+  (let [[doc name+sig] (let [lst (last name+sig+doc)]
+                         (if (string? lst)
+                           [lst (butlast name+sig+doc)]
+                           [nil name+sig+doc]))
+        [method-name sig] (maybe-split-first utils/simple-symbol? name+sig)
+        _ (assert! (utils/simple-symbol? method-name) "Missing method name %s" (pr-str method-name))
+        [output-schema sig] (let [fst (first sig)]
+                              (if (= :- fst)
+                                (let [nxt (next sig)]
+                                  (assert! nxt "Missing schema after :- in %s" method-name)
+                                  [(first nxt) (next nxt)])
+                                [`schema.core/Any sig]))
+        _ (assert (seq sig))
+        binds (mapv #(process-arrow-schematized-args env %)
+                    sig)
+        cljs? (cljs-env? env)]
+    {:sig (->> (concat (cons method-name binds) (when doc [doc]))
+               ;; work around https://clojure.atlassian.net/browse/CLJS-3211
+               (apply list))
+     :method-name method-name
+     :schema-form `(schema.core/=>* ~output-schema ~@(map #(mapv (comp :schema meta) %) binds))
+     :instrument-method (let [outer-mth-meta (-> (or (meta method-name) {})
+                                                 (dissoc :always-validate :never-validate)
+                                                 (into 
+                                                   (cond
+                                                     (-> method-name meta :never-validate) {:never-validate true}
+                                                     (-> method-name meta :always-validate) {:always-validate true}
+                                                     (-> pname meta :never-validate) {:never-validate true}
+                                                     (-> pname meta :always-validate) {:always-validate true}))
+                                                 not-empty)
+                              inner-mth (gensym)
+                              gen-binder (fn [gs bind]
+                                           (vec (mapcat #(list %1 :- (-> %2 meta :schema)) gs bind)))
+                              gen-bind-syms (fn [bind]
+                                              (mapv (fn [s]
+                                                      (if (symbol? s)
+                                                        (gensym (str (name s) "__"))
+                                                        (gensym)))
+                                                    bind))]
+                          (cond
+                            cljs?
+                            (let [cljs-nsym (-> env :ns :name)
+                                  ->arity-sym #(symbol (str cljs-nsym "." method-name ".cljs$core$IFn$_invoke$arity$" %))
+                                  arities (into {}
+                                                (map (fn [bind]
+                                                       [(count bind) (gensym)])
+                                                     binds))]
+                              `(let ~(vec (mapcat (fn [[i g]]
+                                                    [g (if (= 1 (count arities))
+                                                         ;; just one arity, wrap method-name
+                                                         method-name
+                                                         ;; multiple arites, wrap each arity individually. don't save/call old method-name
+                                                         ;; as it will dispatch right back to the wrapper's arities in an infinite loop.
+                                                         (->arity-sym i))])
+                                                  arities))
+                                 ;; use defn instead of set! to completely hide the $arity$ methods of the underlying protocol
+                                 ;; in case the cljs compiler attempts inlining.
+                                 (schema.core/defn ~(with-meta method-name
+                                                               (assoc outer-mth-meta
+                                                                      :protocol (symbol (name cljs-nsym) (name pname))
+                                                                      :doc doc))
+                                   :- ~output-schema
+                                   ~@(map (fn [bind]
+                                            (let [arity (count bind)
+                                                  gs (gen-bind-syms bind)
+                                                  inner-mth (get arities arity)
+                                                  _ (assert inner-mth)]
+                                              (list (gen-binder gs bind)
+                                                    (cons inner-mth gs))))
+                                          binds))))
+                            :else
+                            (let [outer-mth (gensym (str method-name "__"))
+                                  sync! (gensym)]
+                              `(-instrument-protocol-method
+                                 (var ~pname)
+                                 (var ~method-name)
+                                 ;; a function that wraps a protocol method in a schema check with a
+                                 ;; cache synchronization point
+                                 (fn [~inner-mth ~sync!]
+                                   (schema.core/fn ~(with-meta outer-mth outer-mth-meta)
+                                     :- ~output-schema
+                                     ~@(map (fn [bind]
+                                              (let [gs (gen-bind-syms bind)]
+                                                (list (gen-binder gs bind)
+                                                      (list sync! outer-mth inner-mth)
+                                                      (cons inner-mth gs))))
+                                            binds)))))))}))
+
+(defn process-defprotocol [env name+opts+sigs]
+  (let [[pname opts+sigs] (maybe-split-first utils/simple-symbol? name+opts+sigs)
+        _ (assert! (utils/simple-symbol? pname) "Missing protocol name: %s" (pr-str pname))
+        [doc opts+sigs] (maybe-split-first string? opts+sigs)
+        [opts sigs] (loop [preamble []
+                           [fst :as opts+sigs] opts+sigs]
+                      (if (keyword? fst)
+                        (let [nxt (next opts+sigs)]
+                          (assert! nxt "Uneven args to defprotocol %s" pname)
+                          (recur (conj preamble fst (first nxt))
+                                 (next nxt)))
+                        [preamble opts+sigs]))]
+    {:pname pname
+     :opts opts
+     :doc doc
+     :parsed-sigs (mapv (partial parse-defprotocol-sig env pname) sigs)}))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public: helpers for schematized functions
 

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -75,7 +75,7 @@
    See the docstrings of defrecord, fn, and defn for more details about how
    to use these macros."
   ;; don't exclude def because it's not a var.
-  (:refer-clojure :exclude [Keyword Symbol Inst atom defrecord defn letfn defmethod fn MapEntry ->MapEntry])
+  (:refer-clojure :exclude [Keyword Symbol Inst atom defprotocol defrecord defn letfn defmethod fn MapEntry ->MapEntry])
   (:require
    #?(:clj [clojure.pprint :as pprint])
    [clojure.string :as str]
@@ -88,26 +88,12 @@
   #?(:cljs (:require-macros [schema.macros :as macros]
                             schema.core)))
 
-#?(:clj (def clj-1195-fixed?
-          (do (defprotocol CLJ1195Check
-                (dummy-method [this]))
-              (try
-                (eval '(extend-protocol CLJ1195Check nil
-                         (dummy-method [_])))
-                true
-                (catch RuntimeException _
-                  false)))))
-
-#?(:clj (when-not clj-1195-fixed?
-         ;; don't exclude fn because of bug in extend-protocol
-         (refer-clojure :exclude '[Keyword Symbol Inst atom defrecord defn letfn defmethod])))
-
 #?(:clj (set! *warn-on-reflection* true))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schema protocol
 
-(defprotocol Schema
+(clojure.core/defprotocol Schema
   (spec [this]
     "A spec is a record of some type that expresses the structure of this schema
      in a declarative and/or imperative way.  See schema.spec.* for examples.")
@@ -521,7 +507,7 @@
 
 ;; cond-pre (conditional based on surface type)
 
-(defprotocol HasPrecondition
+(clojure.core/defprotocol HasPrecondition
   (precondition [this]
     "Return a predicate representing the Precondition for this schema:
      the predicate returns true if the precondition is satisfied.
@@ -1262,9 +1248,6 @@
   (or (utils/class-schema (utils/fn-schema-bearer f))
       (macros/safe-get (meta f) :schema)))
 
-;; work around bug in extend-protocol (refers to bare 'fn, so we can't exclude it).
-#?(:clj (when-not clj-1195-fixed? (ns-unmap *ns* 'fn)))
-
 #?(:clj
 (defmacro fn
   "s/fn : s/defn :: clojure.core/fn : clojure.core/defn
@@ -1400,6 +1383,93 @@
        addMethod
        ~dispatch-val
        (fn ~(with-meta (gensym (str (name multifn) "__")) (meta multifn)) ~@fn-tail)))))
+
+(defonce
+  ^{:doc
+    "If the s/defprotocol instrumentation strategy is problematic
+    for your platform, set atom to true and instrumentation will not
+    be performed.
+
+    Defaults to false."}
+  ^:dynamic *elide-defprotocol-instrumentation* 
+  (clojure.core/atom false))
+
+(clojure.core/defn instrument-defprotocol?
+  "If true, elide s/defprotocol instrumentation.
+
+  Instrumentation is elided for any of the following cases:
+  *   @*elide-defprotocol-instrumentation* is true during s/defprotocol macroexpansion
+  *   @*elide-defprotocol-instrumentation* is true during s/defprotocol evaluation"
+  []
+  (not @*elide-defprotocol-instrumentation*))
+
+#?(:clj
+(defmacro defprotocol
+  "Like clojure.core/defprotocol, except schema-style typehints can be provided for
+  the argument symbols and after method names (for output schemas).
+
+  ^:always-validate and ^:never-validate metadata can be specified for all
+  methods on the protocol name. If specified on the method name, ignores
+  the protocol name metatdata and uses the method name metadata.
+
+  Examples:
+
+    (s/defprotocol MyProtocol
+      \"Docstring\"
+      :extend-via-metadata true
+      (^:always-validate method1 :- s/Int
+        [this a :- s/Bool]
+        [this a :- s/Any, b :- s/Str]
+        \"Method doc2\")
+      (^:never-validate method2 :- s/Int
+        [this]
+        \"Method doc2\"))
+  
+  Gotchas and limitations:
+  - Implementation details are used to instrument protocol methods for schema
+    checking. This is tested against a variety of platforms and versions,
+    however if this is problematic for your environment, use
+    *elide-defprotocol-instrumentation* to disable such instrumentation
+    (either at compile-time or runtime depending on your needs).
+    In ClojureScript, method var metadata will be overwritten unless disabled
+    at compile-time. 
+  - :schema metadata on protocol method vars is only supported in Clojure.
+  - Clojure will never inline protocol methods, as :inline metadata is added to protocol
+    methods designed to defeat potential short-circuiting of schema checks. This also means
+    compile-time errors for arity errors are suppressed (eg., `No single method` errors)."
+  [& name+opts+sigs]
+  (let [{:keys [pname doc opts parsed-sigs]} (macros/process-defprotocol &env name+opts+sigs)
+        sigs (map :sig parsed-sigs)
+        defprotocol-form `(clojure.core/defprotocol
+                            ~pname
+                            ~@(when doc [doc])
+                            ~@opts
+                            ~@sigs)
+        instrument? (instrument-defprotocol?)]
+    `(do ~defprotocol-form
+         ;; put everything that relies on protocol implementation details here so the user can
+         ;; turn it off for whatever reason.
+         ~@(when instrument?
+             (map (fn [{:keys [method-name instrument-method]}]
+                    `(when (instrument-defprotocol?)
+                       ~instrument-method))
+                  parsed-sigs))
+         ;; we always want s/fn-schema to work on protocol methods and have :schema
+         ;; metadata on the var in Clojure.
+         ~@(map (fn [{:keys [method-name schema-form]}]
+                  `(let [fn-schema# ~schema-form]
+                     ;; utils/declare-class-schema! works for subtly different reasons for each platform:
+                     ;; :clj -- while CLJ-1796 means a method will change its identity after -reset-methods,
+                     ;;         it does not change its class, as the same method builder is used each time.
+                     ;;         fn-schema-bearer uses the class in :clj, so we're ok.
+                     ;; :cljs -- method identity never changes, and fn-schema-bearer uses function identity in :cljs.
+                     (utils/declare-class-schema! (utils/fn-schema-bearer ~method-name) fn-schema#)
+                     ;; also add :schema metadata like s/defn
+                     (macros/if-cljs
+                       nil
+                       (alter-meta! (var ~method-name) assoc :schema fn-schema#))))
+                parsed-sigs)
+         ~pname))))
 
 #?(:clj
 (defmacro letfn

--- a/src/cljc/schema/utils.cljc
+++ b/src/cljc/schema/utils.cljc
@@ -1,6 +1,6 @@
 (ns schema.utils
   "Private utilities used in schema implementation."
-  (:refer-clojure :exclude [record?])
+  (:refer-clojure :exclude [record? simple-symbol?])
   #?(:clj (:require [clojure.string :as string])
      :cljs (:require
              goog.string.format
@@ -78,6 +78,9 @@
   #?(:clj (instance? clojure.lang.IRecord x)
      :cljs (satisfies? IRecord x)))
 
+(defn simple-symbol? [x]
+  (and (symbol? x)
+       (not (namespace x))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Error descriptions

--- a/test/cljc/schema/core_test.cljc
+++ b/test/cljc/schema/core_test.cljc
@@ -10,10 +10,12 @@
   #?(:cljs (:use-macros
              [cljs.test :only [is deftest testing are]]
              [schema.test-macros :only [valid! invalid! invalid-call!]]))
-  #?(:cljs (:require-macros [schema.macros :as macros]))
+  #?(:cljs (:require-macros [clojure.template :refer [do-template]]
+                            [schema.macros :as macros]))
   (:require
    [clojure.string :as str]
    #?(:clj [clojure.pprint :as pprint])
+   #?(:clj [clojure.template :refer [do-template]])
    clojure.data
    [schema.utils :as utils]
    [schema.core :as s]
@@ -1460,7 +1462,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;  Helpers for defining schemas (used in in-progress work, expanlation coming soon)
+;;;  Helpers for defining schemas (used in in-progress work, explanation coming soon)
 
 (s/defschema TestFoo {:bar s/Str})
 
@@ -1526,3 +1528,156 @@
       (catch Exception e
         (is (re-find #"ef408750"
                      (#?(:cljs .-message :clj .getMessage) e)))))))
+
+
+;; s/defprotocol
+
+(defprotocol ProtAssumptions
+  (prot-assumptions [this a] [this a b] "foo"))
+
+(s/defprotocol PDefProtocolTest1
+  "Doc"
+  (defprotocoltest1-method1
+    :- s/Str
+    ;; IMPORTANT don't remove arities, specifically tests 2 arities
+    [this a :- s/Int]
+    [this a :- s/Int, b :- s/Any]
+    "doc 1")
+  (defprotocoltest1-method2
+    :- s/Str
+    ;; IMPORTANT don't add arities, specifically tests 1 arity
+    [this a :- s/Int, b :- s/Any]
+    "doc 2"))
+
+(deftest protocol-assumptions-test
+  #?(:clj
+     (testing "methods never have :inline meta by default"
+       (is (= {}
+              (-> (var prot-assumptions)
+                  meta
+                  (select-keys [:inline :inline-arities]))))))
+  #?(:cljs
+     (testing ":protocol meta on method vars is the protocol name"
+       (testing "cc/defprotocol"
+         (is (= `ProtAssumptions
+                (-> (var prot-assumptions)
+                    meta
+                    :protocol))))
+       (testing "s/defprotocol"
+         (is (= `PDefProtocolTest1
+                (-> (var defprotocoltest1-method1)
+                    meta
+                    :protocol))))))
+  (testing ":doc meta on method vars"
+    (testing "cc/defprotocol"
+      (is (= "foo"
+             (-> (var prot-assumptions)
+                 meta
+                 :doc))))
+    (testing "cc/defprotocol"
+      (is (str/ends-with?
+            (-> (var defprotocoltest1-method1)
+                meta
+                :doc)
+            "doc 1")))))
+
+(deftype TDefProtocolTest1 []
+  PDefProtocolTest1
+  (defprotocoltest1-method1 [this a] (str a))
+  (defprotocoltest1-method1 [this a b] b)
+  (defprotocoltest1-method2 [this a b] b))
+
+(s/defprotocol PDefProtocolTestDefault
+  ;; test two arities
+  (pdefprotocol-test-default1 :- s/Str
+    [this a :- s/Int]
+    [this a :- s/Int, b :- s/Any])
+  ;; test single arity
+  (pdefprotocol-test-default2 :- s/Str
+    [this a :- s/Int, b :- s/Any]))
+
+(extend-protocol PDefProtocolTestDefault
+  #?(:clj Object
+     ;; default stored in "_" field of protocol method
+     :cljs default)
+  (pdefprotocol-test-default1
+    ([this a] (str a))
+    ([this a b] b))
+  (pdefprotocol-test-default2 [this a b] b))
+
+(deftest sdefprotocol-test
+  (do-template
+    [WRAP] (testing (pr-str 'WRAP)
+             (WRAP
+               (is (= "1" (defprotocoltest1-method1 (->TDefProtocolTest1) 1)))
+               (testing "default dispatch"
+                 (is (= "1" (pdefprotocol-test-default1 :foo 1)))
+                 (is (= "1" (pdefprotocol-test-default1 :foo 1 "1")))
+                 (is (= "2" (pdefprotocol-test-default1 "str" 2)))
+                 (is (= "2" (pdefprotocol-test-default1 "str" 2 "2")))
+                 (is (= "3" (pdefprotocol-test-default1 'a 3)))
+                 (is (= "3" (pdefprotocol-test-default1 'a 3 "3"))))))
+    do
+    s/with-fn-validation
+    s/without-fn-validation)
+  (testing "metadata"
+    (is (= "Doc" (-> #'PDefProtocolTest1 meta :doc)))
+    #?(:clj (is (= "doc 1" (-> #'defprotocoltest1-method1 meta :doc))))
+    #?(:clj (is (= "doc 2" (-> #'defprotocoltest1-method2 meta :doc))))
+    (is (= (s/=>* s/Str [s/Any s/Int] [s/Any s/Int s/Any])
+           (s/fn-schema defprotocoltest1-method1)))
+    #?(:clj (is (= (s/=>* s/Str [s/Any s/Int] [s/Any s/Int s/Any])
+                   (-> #'defprotocoltest1-method1 meta :schema)))))
+  #_ ;; :inline metatdata on methods we add to prevent inlining thwarts this compile-time error
+  #?(:clj
+     (is (thrown-with-msg?
+           Exception #"No single method"
+           (eval `#(defprotocoltest1-method1 (->TDefProtocolTest1))))))
+  (testing "default method errors"
+    (s/with-fn-validation
+      (invalid-call! pdefprotocol-test-default1 :foo nil) ;;input
+      (invalid-call! pdefprotocol-test-default1 :foo nil "a") ;;input
+      (invalid-call! pdefprotocol-test-default1 :foo 1 :a) ;;output
+      (invalid-call! pdefprotocol-test-default1 "str" :foo) ;;input
+      (invalid-call! pdefprotocol-test-default1 "str" :foo :a) ;;input
+      (invalid-call! pdefprotocol-test-default1 "str" 1 :a))) ;;output
+  (testing "inlinable positions"
+    (s/with-fn-validation
+      (is (= "1" (defprotocoltest1-method1 (->TDefProtocolTest1) 1)))
+      (is (= "a" (defprotocoltest1-method1 (->TDefProtocolTest1) 1 "a")))
+      (is (= "a" (defprotocoltest1-method2 (->TDefProtocolTest1) 1 "a"))))
+    (s/with-fn-validation
+      (invalid-call! defprotocoltest1-method1 (->TDefProtocolTest1) :a)
+      (testing "input"
+        (invalid-call! defprotocoltest1-method1 (->TDefProtocolTest1) ::foo "a"))
+      (testing "output"
+        (invalid-call! defprotocoltest1-method1 (->TDefProtocolTest1) 1 ::foo))
+      (invalid-call! defprotocoltest1-method2 (->TDefProtocolTest1) 1 ::foo))
+    ;; try a bunch of contexts and nestings to make sure inlining is defeated
+    #?(:clj 
+       (do
+         (s/with-fn-validation
+           (invalid-call! (eval `(defprotocoltest1-method1 (->TDefProtocolTest1) :a))))
+         (s/with-fn-validation
+           (invalid-call! (eval `(let [] (defprotocoltest1-method1 (->TDefProtocolTest1) :a)))))))))
+
+#?(:clj
+   (s/defprotocol ProtocolCache
+     (protocol-cache [this])))
+
+#?(:clj
+   (deftest clj-protocol-cache-test
+     (let [x 1
+           ;; use partial to hold onto method reference. this acts differently
+           ;; with cc/defprotocol because of CLJ-1796 (cache is never invalidated
+           ;; on old references).
+           call (partial protocol-cache x)]
+       (extend-protocol ProtocolCache
+         Number
+         (protocol-cache [_] :number))
+       (is (= :number (protocol-cache x) (call)))
+       (extend-protocol ProtocolCache
+         Long
+         (protocol-cache [_] :long))
+       (testing "invalidates .__methodImplCache"
+         (is (= :long (protocol-cache x) (call)))))))


### PR DESCRIPTION
Close 117 

Implementation details were needed from both platforms to make this work in practice, but none of the actual dispatching mechanism was copied here, so `s/defprotocol` gracefully inherits the semantics of whichever Clojure/Script version is used.

Luckily these implementation details seem to apply to all tested versions of Clojure/Script.

Some of the more interesting issues encountered:

In Clojure:
- added `:inline` metadata to method vars to prevent the compiler from inlining the method (and skipping schema checks)
- instrument method builders, which are used to reset methods after `extend`
- propagating `.__methodImplCache` without introducing (more) data races required a lock (see `clj-protocol-cache-test` for propagation tests)

In CLJS:
- Some tricky wrapping is needed for multi-arity protocol methods to avoid infinite loops.